### PR TITLE
fixing vcs_submodules var

### DIFF
--- a/tfh/lib/tfh/cmd/tfh_workspace_new.sh
+++ b/tfh/lib/tfh/cmd/tfh_workspace_new.sh
@@ -85,6 +85,10 @@ tfh_workspace_new () {
   oauth_id="$8"
   queue_all_runs="$9"
 
+  if [ -z "$vcs_submodules" ];then
+    vcs_submodules=false
+  fi
+  
   if [ -z "$new_ws" ]; then
     if ! check_required ws; then
       echoerr 'For workspace commands, a positional parameter is also accepted:'


### PR DESCRIPTION
setting vcs_submodules to false if not provided, previously failing as:

```
$ tfh workspace new flavio -terraform-version 0.11.13-custom -vcs-id ftorre2/customer -oauth-id oc-xxxx

[ERROR] API request failed.
HTTP status code: 400
JSON-API details:
  detail: 765: unexpected token at '{"data": {  "type": "workspaces",  "attributes": {    "vcs-repo": {    "identifier": "ftorre2/customer",    "oauth-token-id": "oc-xxx",    "ingress-submodules": ,    "branch": ""    },    "terraform-version": "0.11.13-custom",      "working-directory": "",      "auto-apply": false,      "queue-all-runs": false,      "name": "flavio"    }  }}'
  status: 400
  title: JSON body is invalid
```