### PR TITLE
fix a typo that causes inconsistency

### DIFF
--- a/tfh/lib/tfh/cmd/tfh_run_cancel.sh
+++ b/tfh/lib/tfh/cmd/tfh_run_cancel.sh
@@ -29,7 +29,7 @@ tfh_run_cancel () {
     return 1
   fi
 
-  if [ -z "$run_id" ]; then
+  if [ -z "$run_ids" ]; then
     # get the run ID of the last run in a cancelable state and use that
     if ! check_required org ws; then
       echoerr "need org and workspace to locate cancelable run"

--- a/tfh/lib/tfh/cmd/tfh_run_discard.sh
+++ b/tfh/lib/tfh/cmd/tfh_run_discard.sh
@@ -29,7 +29,7 @@ tfh_run_discard () {
     return 1
   fi
 
-  if [ -z "$run_id" ]; then
+  if [ -z "$run_ids" ]; then
     # get the run ID of the last run in a discardable state and use that
     if ! check_required org ws; then
       echoerr "need org and workspace to locate discardable run"


### PR DESCRIPTION
due to the typo in the if condition, when the user provides
a run id argument, the script ignores it and instead queries
suitable runs from runs list resulting in a possibility of
cancelation or discardment of more runs than initially intended.