### PR TITLE
feature: add possibility to remove vcs settings for cli/api driven workflow

### DIFF
--- a/tfh/lib/tfh/cmd/tfh_workspace_update.sh
+++ b/tfh/lib/tfh/cmd/tfh_workspace_update.sh
@@ -131,7 +131,6 @@ tfh_workspace_update () {
     return 1
   fi
 
-  cat "$payload"
   cleanup "$payload"
 
   echo "Updated workspace $org/$up_ws"

--- a/tfh/lib/tfh/cmd/tfh_workspace_update.sh
+++ b/tfh/lib/tfh/cmd/tfh_workspace_update.sh
@@ -50,7 +50,8 @@ tfh_workspace_update () {
   vcs_submodules="$7"
   oauth_id="$8"
   remove_vcs="$9"
-  queue_all_runs="$10"
+  queue_all_runs="${10}"
+  execution_mode="${11}"
 
   payload="$TMPDIR/tfe-migrate-payload-$(junonia_randomish_int)"
 
@@ -113,6 +114,11 @@ tfh_workspace_update () {
     attr_obj="$attr_obj \"vcs-repo\": null"
   fi
 
+  if [ -n "$execution_mode" ] && echo "$TFH_CMDLINE" | grep -Eq -- '-execution-mode'; then
+        [ "$attr_obj" ] && attr_obj="$attr_obj,"
+        attr_obj="$attr_obj \"execution-mode\": \"$execution_mode\""
+  fi
+
   if [ "$vcs_obj" ]; then
     [ "$attr_obj" ] && attr_obj="$attr_obj,"
     attr_obj="$attr_obj \"vcs-repo\": {$vcs_obj}"
@@ -130,6 +136,7 @@ tfh_workspace_update () {
     echoerr "Error updating workspace $org/$up_ws"
     return 1
   fi
+
 
   cleanup "$payload"
 

--- a/tfh/lib/tfh/cmd/tfh_workspace_update.sh
+++ b/tfh/lib/tfh/cmd/tfh_workspace_update.sh
@@ -49,7 +49,8 @@ tfh_workspace_update () {
   vcs_branch="$6"
   vcs_submodules="$7"
   oauth_id="$8"
-  queue_all_runs="$9"
+  remove_vcs="$9"
+  queue_all_runs="$10"
 
   payload="$TMPDIR/tfe-migrate-payload-$(junonia_randomish_int)"
 
@@ -106,6 +107,12 @@ tfh_workspace_update () {
         vcs_obj="$vcs_obj \"oauth-token-id\": \"$oauth_id\""
   fi
 
+  if [ $remove_vcs ] && echo "$TFH_CMDLINE" | grep -Eq -- '-remove-vcs'; then
+    vcs_obj=
+    [ "$attr_obj" ] && attr_obj="$attr_obj,"
+    attr_obj="$attr_obj \"vcs-repo\": null"
+  fi
+
   if [ "$vcs_obj" ]; then
     [ "$attr_obj" ] && attr_obj="$attr_obj,"
     attr_obj="$attr_obj \"vcs-repo\": {$vcs_obj}"
@@ -124,6 +131,7 @@ tfh_workspace_update () {
     return 1
   fi
 
+  cat "$payload"
   cleanup "$payload"
 
   echo "Updated workspace $org/$up_ws"

--- a/tfh/usr/share/doc/tfh/tfh_workspace_update.md
+++ b/tfh/usr/share/doc/tfh/tfh_workspace_update.md
@@ -46,6 +46,10 @@ If true, when the configuration is ingressed from the VCS service VCS submodules
 
 The OAuth ID to be used with the VCS integration.
 
+* `-remove-vcs`
+
+Remove the VCS integration.
+
 * `-queue-all-runs`
 
 If true, runs will be queued immediately after workspace creation. If false, runs will not queue until a run is manually queued first. Defaults to false.

--- a/tfh/usr/share/doc/tfh/tfh_workspace_update.md
+++ b/tfh/usr/share/doc/tfh/tfh_workspace_update.md
@@ -54,3 +54,6 @@ Remove the VCS integration.
 
 If true, runs will be queued immediately after workspace creation. If false, runs will not queue until a run is manually queued first. Defaults to false.
 
+* `-execution-mode MODE`
+
+Which execution mode to use. Valid values are "remote", "local", and "agent".


### PR DESCRIPTION
This new option `-remove-vcs` will override all other given vcs options and will send a payload to reconfigure vcs settings on the workspace.